### PR TITLE
explicitly reference utils.escape

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import { merge } from './utils'
+import { merge, escape } from './utils'
 import defaultOptions from './defaults'
 import Parser from './parser'
 import Lexer from './lexer'


### PR DESCRIPTION
The original code works fine since rollup concat everything.
Also, ESLint did not catch it because node has a deprecated global querystring escape function.
However, I do not think rely on this behavior is correct.
