### PR TITLE
Don't add target attr to anchors with id hrefs

### DIFF
--- a/src/renderer.js
+++ b/src/renderer.js
@@ -135,7 +135,7 @@ export default class Renderer {
     if (title) {
       out += ` title="${title}"`
     }
-    if (this.options.linksInNewTab) {
+    if (this.options.linksInNewTab && href[0] !== '#') {
       out += ` target="_blank"`
     }
     out += `>${text}</a>`


### PR DESCRIPTION
This update will check link hrefs to make they don't have a leading "#" character before adding the `target="_blank"` attribute