### PR TITLE
Feature: add default codespan class option for correct PrismJS highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ A modern **markdown** parser!
 `)
 ```
 
-You can preview the HTML result here: https://egoist.moe/md2html/ ([source](https://github.com/egoist/md2html))
+You can preview the HTML result here: https://md2html.egoist.rocks/ ([source](https://github.com/egoist/md2html))
 
 ## API
 
@@ -95,6 +95,9 @@ This will yield:
 ## Development
 
 ```bash
+# install the dependencies
+yarn # or yarn install
+
 # lint and unit test
 yarn test
 
@@ -102,7 +105,7 @@ yarn test
 yarn lint
 
 # fix lint issues
-yarn lint -- --fix
+yarn lint --fix
 ```
 
 ## Author

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Open links in a new window/tab.
 Type: `boolean`<br>
 Default: `true`
 
-Add `data-line` attribute to `<pre>` tag for code fences, it's useful with the [line-highlight](http://prismjs.com/plugins/line-highlight/) plugin in PrismJS. 
+Add `data-line` attribute to `<pre>` tag for code fences, it's useful with the [line-highlight](http://prismjs.com/plugins/line-highlight/) plugin in PrismJS.
 
 ````markdown
 ```js{1}
@@ -81,6 +81,24 @@ This will yield:
 
 ```html
 <pre data-line="1"><code class="lang-js">console.log('hi')</code></pre>
+```
+
+##### codeSpanHighlighted
+
+Type: `boolean`<br>
+Default: `false`
+
+Adds default class `lang-markup` to inline `<code>` elements, so they will be automatically highlighted with PrismJS.
+The `lang-` prefix is configured by the default [options](https://marked.js.org/#/USING_ADVANCED.md#options) of Marked.js.
+
+````markdown
+paragraph with code: `console.log('hi')`.
+````
+
+This will yield:
+
+```html
+<p>paragraph with code: <code class="lang-markup">console.log('hi')</code>.</p>
 ```
 
 ## Contributing

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -17,5 +17,6 @@ export default {
   smartypants: false,
   headerPrefix: '',
   renderer: new Renderer(),
-  xhtml: false
+  xhtml: false,
+  codeSpanHighlighted: false
 }

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -112,7 +112,8 @@ export default class Renderer {
   codespan(text) {
     if (this.options.codeSpanHighlighted) {
       const defaultInlineLanguage = 'markup'
-      return `<code class="${this.options.langPrefix}${defaultInlineLanguage}">${text}</code>`
+      return `<code class="${this.options
+        .langPrefix}${defaultInlineLanguage}">${text}</code>`
     }
     return `<code>${text}</code>`
   }

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -110,6 +110,10 @@ export default class Renderer {
   }
 
   codespan(text) {
+    if (this.options.codeSpanHighlighted) {
+      const defaultInlineLanguage = 'markup'
+      return `<code class="${this.options.langPrefix}${defaultInlineLanguage}">${text}</code>`
+    }
     return `<code>${text}</code>`
   }
 

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -8,6 +8,11 @@ exports[`data-line 1`] = `
 "
 `;
 
+exports[`default inline code 1`] = `
+"<p>Paragraph with <code>some inline code</code>.</p>
+"
+`;
+
 exports[`headings 1`] = `
 "<h1 id=\\"hello\\">hello</h1>
 <h1 id=\\"hello-1\\">hello</h1>
@@ -15,7 +20,7 @@ exports[`headings 1`] = `
 "
 `;
 
-exports[`inline-code 1`] = `
+exports[`inline code with classes 1`] = `
 "<p>Paragraph with <code class=\\"lang-markup\\">some inline code</code>.</p>
 "
 `;

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -15,6 +15,11 @@ exports[`headings 1`] = `
 "
 `;
 
+exports[`inline-code 1`] = `
+"<p>Paragraph with <code class=\\"lang-markup\\">some inline code</code>.</p>
+"
+`;
+
 exports[`links 1`] = `
 "<p><a href=\\"b\\">a</a></p>
 "

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -70,3 +70,13 @@ hello
 
   expect(html).toMatchSnapshot()
 })
+
+test('inline-code', () => {
+  const html = marked(`
+Paragraph with \`some inline code\`.
+  `,
+    { codeSpanHighlighted: true }
+  )
+
+  expect(html).toMatchSnapshot()
+})

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -71,12 +71,21 @@ hello
   expect(html).toMatchSnapshot()
 })
 
-test('inline-code', () => {
-  const html = marked(`
+test('inline code with classes', () => {
+  const html = marked(
+    `
 Paragraph with \`some inline code\`.
   `,
     { codeSpanHighlighted: true }
   )
+
+  expect(html).toMatchSnapshot()
+})
+
+test('default inline code', () => {
+  const html = marked(`
+Paragraph with \`some inline code\`.
+  `)
 
   expect(html).toMatchSnapshot()
 })


### PR DESCRIPTION
Default code spans (with back-ticks) where not being highlighted by prismjs (`<code>inline</code>`), because they were lacking the default class: `language-markup`

- Added option with `false` by default.
- Added tests.
- Corrected link to md2html on readme.
- Corrected development commands on readme.

## Edit:
Added codesandbox: https://codesandbox.io/s/yjn2vxqn2z